### PR TITLE
Fix offline mode for dependency packages

### DIFF
--- a/Sources/SlnLauncher/Program.cs
+++ b/Sources/SlnLauncher/Program.cs
@@ -307,6 +307,11 @@ namespace SlnLauncher
                 foreach (var p in slnx.Packages)
                 {
                     p.Source = nugetCacheUri;
+                    if (p.DependencySources?.Count > 0)
+                    {
+                        p.DependencySources.Clear();
+                        p.DependencySources.Add(nugetCacheUri);
+                    }
                 }
             }
 


### PR DESCRIPTION
In offline mode override also the additional
source list with the local cache in order to avoid
external connections.