### PR TITLE
IsPackable element evaluation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <AssemblyVersion>2.4.2</AssemblyVersion>
+   <AssemblyVersion>2.5.0</AssemblyVersion>
     <Version>$(AssemblyVersion)</Version> <!-- If repacked, it might be required to set this as the NuGet SDK. -->
  </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,15 @@ Defintion of a C# project to be added to the solution.
 | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | name      | -       | Name of the environment variable to be set.<br>Wild cards (\*) can be used to match multiple projects.                                                                                                                                                                         |
 | container | *none*  | This value can be used to define a subdirectory in the VS Solution file, in which the project will be placed.<br>The container can have multiple sub-directories (ex: Libs/Bar/Foo)<br>If not set, all Test projects are automatically placed under a container called "Test". |
-| packable  | true    | If set to false, this project is not being conisdered in the generation of the nuspec file.<br>Useful to avoid to include test projects.                                                                                                                                       |
+
+- - -
+
+**NOTE:**
+The tool evaluates the \<IsPackable\> element within the CsProj file (Microsoft.NET.Sdk style projects only!).<br>
+If set to false, this project is not being considered in the generation of the nuspec file.<br>
+Useful to avoid to include test assemblies in the package.
+
+- - -
 <br>
 
 ### debug

--- a/Sources/Slnx/CsProject.cs
+++ b/Sources/Slnx/CsProject.cs
@@ -62,12 +62,11 @@ namespace Slnx
         List<Generated.ProjectReference> _projectReferences = null;
         Logger _logger = Logger.Instance;
 
-        public CsProject(string fullpath, string container, bool isPackable)
+        public CsProject(string fullpath, string container)
         {
             _logger.Debug($"Processing project: {fullpath}");
 
             bool projectContentModified = false;
-            IsPackable = isPackable;
 
             _typeGuid = CsProjectTypeGuid.ToUpper();
 
@@ -111,6 +110,7 @@ namespace Slnx
                 }
 
                 Framework = GetFramework("TargetFramework");
+                IsPackable = GetIsPackable();
             }
             else
             {
@@ -119,6 +119,7 @@ namespace Slnx
 
                 var projectNewContent = _projectOriginalContent;
                 Framework = GetFramework("TargetFrameworkVersion");
+                IsPackable = true;
 
                 var m = _guidRegex.Match(projectNewContent);
                 if (m.Success)
@@ -423,6 +424,17 @@ namespace Slnx
                 return true;
             }
             return false;
+        }
+
+        private bool GetIsPackable(bool defaultValue = true)
+        {
+            var ret = defaultValue;
+            var elements = _xml.GetElementsByTagName("IsPackable");
+            foreach(XmlNode e in elements)
+            {
+                bool.TryParse(e.InnerText, out ret);
+            }
+            return ret;
         }
 
         private string GetFramework(string tag)

--- a/Sources/Slnx/Generated/SlnX.cs
+++ b/Sources/Slnx/Generated/SlnX.cs
@@ -610,10 +610,6 @@ namespace Slnx.Generated {
         
         private string containerField;
         
-        private bool packableField;
-        
-        private bool packableFieldSpecified;
-        
         private string valueField;
         
         /// <remarks/>
@@ -635,28 +631,6 @@ namespace Slnx.Generated {
             }
             set {
                 this.containerField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public bool packable {
-            get {
-                return this.packableField;
-            }
-            set {
-                this.packableField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool packableSpecified {
-            get {
-                return this.packableFieldSpecified;
-            }
-            set {
-                this.packableFieldSpecified = value;
             }
         }
         

--- a/Sources/Slnx/SlnxHandler.cs
+++ b/Sources/Slnx/SlnxHandler.cs
@@ -339,7 +339,7 @@ namespace Slnx
                     container = string.Join("/", enforcedContainer, container);
                 }
 
-                var p = new CsProject(knownProject[0], container, !requestedProject.packableSpecified || requestedProject.packable);
+                var p = new CsProject(knownProject[0], container);
                 _projects.Add(p);
             }
         }

--- a/XSDs/AssemblyReference.xsd
+++ b/XSDs/AssemblyReference.xsd
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:element name="Reference" type="AssemblyReference">
-		<xs:annotation>
-			<xs:documentation>Root element</xs:documentation>
-		</xs:annotation>
-	</xs:element>
-	<xs:complexType name="AssemblyReference">
-		<xs:all>
-			<xs:element name="HintPath" type="xs:string" />
-		</xs:all>
-		<xs:attribute name="Include" use="required"/>
-		<xs:attribute name="Condition" use="optional"/>
-	</xs:complexType>
+    <xs:element name="Reference" type="AssemblyReference">
+        <xs:annotation>
+            <xs:documentation>Root element</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="AssemblyReference">
+        <xs:all>
+            <xs:element name="HintPath" type="xs:string" />
+        </xs:all>
+        <xs:attribute name="Include" use="required"/>
+        <xs:attribute name="Condition" use="optional"/>
+    </xs:complexType>
 </xs:schema>

--- a/XSDs/PackageType.xsd
+++ b/XSDs/PackageType.xsd
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">	
-	<xs:complexType name="PackageType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="id" use="required"/>
-				<xs:attribute name="version" use="required"/>
-				<xs:attribute name="targetFramework" use="optional"/>
-				<xs:attribute name="source" use="optional"/> <!-- URL of the package-feed containing the packages. -->
-				<xs:attribute name="dependencySources" use="optional"/> <!-- URL of the package-feed containing the dependencies of the package. -->
-				<xs:attribute name="var" use="optional"/> <!-- Additional (optional) environment variable name that will be used to locate the package -->
-				<xs:attribute name="dependenciesForceMinVersion" type="xs:boolean"/>
-				<xs:attribute name="IsDotNetLib" type="xs:boolean"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">    
+    <xs:complexType name="PackageType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="id" use="required"/>
+                <xs:attribute name="version" use="required"/>
+                <xs:attribute name="targetFramework" use="optional"/>
+                <xs:attribute name="source" use="optional"/> <!-- URL of the package-feed containing the packages. -->
+                <xs:attribute name="dependencySources" use="optional"/> <!-- URL of the package-feed containing the dependencies of the package. -->
+                <xs:attribute name="var" use="optional"/> <!-- Additional (optional) environment variable name that will be used to locate the package -->
+                <xs:attribute name="dependenciesForceMinVersion" type="xs:boolean"/>
+                <xs:attribute name="IsDotNetLib" type="xs:boolean"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 </xs:schema>

--- a/XSDs/ProjectReference.xsd
+++ b/XSDs/ProjectReference.xsd
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:element name="ProjectReference" type="ProjectReference">
-		<xs:annotation>
-			<xs:documentation>Root element</xs:documentation>
-		</xs:annotation>
-	</xs:element>
-	<xs:complexType name="ProjectReference">
-		<xs:attribute name="Include" use="required"/>
-	</xs:complexType>
+    <xs:element name="ProjectReference" type="ProjectReference">
+        <xs:annotation>
+            <xs:documentation>Root element</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="ProjectReference">
+        <xs:attribute name="Include" use="required"/>
+    </xs:complexType>
 </xs:schema>

--- a/XSDs/SlnX.xsd
+++ b/XSDs/SlnX.xsd
@@ -2,100 +2,99 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
     <xs:include schemaLocation="PackageType.xsd"/>
     
-	<xs:element name="SlnX" type="SlnXType">
-		<xs:annotation>
-			<xs:documentation>Root element</xs:documentation>
-		</xs:annotation>
-	</xs:element>
-	<xs:complexType name="SlnXType">
-		<xs:sequence>
-			<xs:element name="nuget" type="NugetType"/>
-			<xs:element name="env" type="EnvType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="project" type="ProjectType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="import" type="ImportType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="bundle" type="BundleType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="package" type="PackageType" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="debug" type="DebugType" minOccurs="0" maxOccurs="unbounded"/>
-		</xs:sequence>
-		<xs:attribute name="sln" use="optional"/>
-		<xs:attribute name="searchPath"/>
-		<xs:attribute name="packagesPath" use="optional"/>
-		<xs:attribute name="skip" use="optional"/>
-	</xs:complexType>
-	<xs:complexType name="NugetType">
-		<xs:all>
-			<xs:element name="id" type="xs:string" />
-			<xs:element name="version" type="xs:string"/>
-			<xs:element name="readme" type="xs:string"/>
-			<xs:element name="targetConfig" type="xs:string"/>
-			<xs:element name="content">
-				<xs:complexType>	
-					<xs:sequence>
-						<xs:element name="item" type="ContentItemType" minOccurs="0" maxOccurs="unbounded"/>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="info">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:any minOccurs="0" maxOccurs="unbounded"/>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-		</xs:all>
-		<xs:attribute name="excludeProjects" type="xs:boolean" use="optional"/>		
-		<xs:attribute name="excludePackages" type="xs:boolean" use="optional"/>		
-	</xs:complexType>
-	<xs:complexType name="ContentItemType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="targetFramework" use="required"/>
-			</xs:extension>			
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:complexType name="FolderType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="targetFramework" use="required"/>
-			</xs:extension>			
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:complexType name="EnvType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="name" use="required"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:complexType name="ProjectType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="name" use="required"/>
-				<xs:attribute name="container" use="optional"/>
-				<xs:attribute name="packable" type="xs:boolean"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:complexType name="BundleType">
-		<xs:sequence>
-			<xs:element name="package" type="PackageType" minOccurs="0" maxOccurs="5000"/>
-		</xs:sequence>
-		<xs:attribute name="name" use="required"/>
-	</xs:complexType>
-	<xs:complexType name="ImportType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<xs:attribute name="path" use="optional"/>
-				<xs:attribute name="bundle" use="optional"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:complexType name="DebugType">
-		<xs:simpleContent>
-			<xs:extension base="xs:string">
-				<!-- If not set, the SlnX file name specified in the value will be used as package name -->
-				<xs:attribute name="package" use="optional"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
+    <xs:element name="SlnX" type="SlnXType">
+        <xs:annotation>
+            <xs:documentation>Root element</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="SlnXType">
+        <xs:sequence>
+            <xs:element name="nuget" type="NugetType"/>
+            <xs:element name="env" type="EnvType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="project" type="ProjectType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="import" type="ImportType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="bundle" type="BundleType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="package" type="PackageType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="debug" type="DebugType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="sln" use="optional"/>
+        <xs:attribute name="searchPath"/>
+        <xs:attribute name="packagesPath" use="optional"/>
+        <xs:attribute name="skip" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="NugetType">
+        <xs:all>
+            <xs:element name="id" type="xs:string" />
+            <xs:element name="version" type="xs:string"/>
+            <xs:element name="readme" type="xs:string"/>
+            <xs:element name="targetConfig" type="xs:string"/>
+            <xs:element name="content">
+                <xs:complexType>    
+                    <xs:sequence>
+                        <xs:element name="item" type="ContentItemType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="info">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="excludeProjects" type="xs:boolean" use="optional"/>        
+        <xs:attribute name="excludePackages" type="xs:boolean" use="optional"/>        
+    </xs:complexType>
+    <xs:complexType name="ContentItemType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="targetFramework" use="required"/>
+            </xs:extension>            
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="FolderType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="targetFramework" use="required"/>
+            </xs:extension>            
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="EnvType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ProjectType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required"/>
+                <xs:attribute name="container" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="BundleType">
+        <xs:sequence>
+            <xs:element name="package" type="PackageType" minOccurs="0" maxOccurs="5000"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="ImportType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="path" use="optional"/>
+                <xs:attribute name="bundle" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="DebugType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <!-- If not set, the SlnX file name specified in the value will be used as package name -->
+                <xs:attribute name="package" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
The tool now evaluates the official <IsPackable> element in the CsProj, instead of using the custom SlnX project attribute.
The packable attribute usage is now dismissed.