### PR TITLE
Igiona/fix debug package reference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <AssemblyVersion>3.1.1</AssemblyVersion>
+   <AssemblyVersion>3.1.2</AssemblyVersion>
     <Version>$(AssemblyVersion)</Version> <!-- If repacked, it might be required to set this as the NuGet SDK. -->
  </PropertyGroup>
 

--- a/Sources/Slnx/SlnxHandler.cs
+++ b/Sources/Slnx/SlnxHandler.cs
@@ -451,10 +451,16 @@ namespace Slnx
             return projectMatch;
         }
 
-        static void AppendReference(XmlNode itemGroup, NuGetPackage package)
+        void AppendReference(XmlNode itemGroup, NuGetPackage package)
         {
-            var condition = string.Format("$({0}) != 1", NuGetClientHelper.NuGetPackage.GetDebugEnvironmentVariableKey(package.Identity.Id));
-            itemGroup.InnerXml += $"<PackageReference Include=\"{package.Identity.Id}\" Version=\"{package.Identity.MinVersion}\" Condition=\"{condition}\"/>";
+            string condition = string.Empty;
+            var isDebugPackage = DebugSlnxItems.Keys.Any(p => p.Identity.Id.Equals(package.Identity.Id, StringComparison.OrdinalIgnoreCase));
+            if (isDebugPackage)
+            {
+                condition = "ExcludeAssets=\"All\""; //Ignore the assets of the packages being debugged, but keep it in the reference list
+            }
+
+            itemGroup.InnerXml += $"<PackageReference Include=\"{package.Identity.Id}\" Version=\"{package.Identity.MinVersion}\" {condition}/>";
         }
 
         private Dictionary<CsProject, XmlDocument> CreatPackageReferenceContent()

--- a/Test/Expected/DebugTestAppAssemblyRef/Ui/slnx.config
+++ b/Test/Expected/DebugTestAppAssemblyRef/Ui/slnx.config
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="NuGet.Common" Version="6.0.0" Condition="$(NuGet_Common_debug) != 1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.0" Condition="$(NuGet_Packaging_debug) != 1" />
+    <PackageReference Include="NuGet.Common" Version="6.0.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Test/Expected/DebugTestAppNugetRef/App/slnx.config
+++ b/Test/Expected/DebugTestAppNugetRef/App/slnx.config
@@ -7,6 +7,6 @@ $#$    <ProjectReference Include=".*\\Test\\Stimuli\\TestApp\\Lib\\TestApp\.Lib\
 $#$    <ProjectReference Include=".*\\Test\\Stimuli\\TestApp\\Ui\\TestApp\.UiUnformattedProj\.csproj" \/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="TestApp" Version="1.0.0" Condition="$(TestApp_debug) != 1" />
+    <PackageReference Include="TestApp" Version="1.0.0" ExcludeAssets="All" />
   </ItemGroup>
 </Project>

--- a/Test/Expected/DebugTestAppNugetRef/Ui/slnx.config
+++ b/Test/Expected/DebugTestAppNugetRef/Ui/slnx.config
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="NuGet.Common" Version="6.0.0" Condition="$(NuGet_Common_debug) != 1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.0" Condition="$(NuGet_Packaging_debug) != 1" />
+    <PackageReference Include="NuGet.Common" Version="6.0.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Test/Expected/TestApp/slnx.config
+++ b/Test/Expected/TestApp/slnx.config
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="NuGet.Common" Version="6.0.0" Condition="$(NuGet_Common_debug) != 1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.0.0" Condition="$(NuGet_Packaging_debug) != 1" />
+    <PackageReference Include="NuGet.Common" Version="6.0.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Test/SlnLauncher.Test/Helper.cs
+++ b/Test/SlnLauncher.Test/Helper.cs
@@ -90,7 +90,7 @@ namespace SlnLauncher.Test
                         {
                             if (!skip.Any(x => resLine.Contains(x)))
                             {
-                                Console.WriteLine($"Error at line {i + 1} in {resultFile}");
+                                Console.WriteLine($"Error at line {i + 1} in {resultFile} vs {expectedFile}");
                                 break;
                             }
                         }

--- a/package/SlnLauncher.nuspec
+++ b/package/SlnLauncher.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>slnlauncher</id>
-    <version>3.1.1</version>
+    <version>3.1.2</version>
     <title>SlnLauncher (Portable)</title>
     <summary>The SlnLauncher is a tool that allows to dyncamically and automatically create VisualStudio solution files (.sln).</summary>
     <description>The SlnLauncher is a tool that allows to dyncamically and automatically create VisualStudio solution files (.sln).


### PR DESCRIPTION
Fully ignoring the package causes issues when it comes to build against other packages that have a dependency to the package being debugged.
The reference cannot be simply ignored or omitted.
Excluding all assets produce the desired behavior.