### PR TITLE
Produce the debug information for all debug packages

### DIFF
--- a/Test/Expected/DebugExtendedTestAppNugetRef/Src/slnx.config
+++ b/Test/Expected/DebugExtendedTestAppNugetRef/Src/slnx.config
@@ -8,5 +8,6 @@ $#$    <ProjectReference Include=".*\\Test\\Stimuli\\TestApp\\Ui\\TestApp.UiUnfo
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="TestApp" Version="1.0.0" ExcludeAssets="All" />
+    <PackageReference Include="ExtendedTestApp" Version="1.0.0" ExcludeAssets="All" />
   </ItemGroup>
 </Project>

--- a/Test/Expected/DebugTestAppAssemblyRef/App/slnx.config
+++ b/Test/Expected/DebugTestAppAssemblyRef/App/slnx.config
@@ -5,4 +5,7 @@
   <ItemGroup>
 $#$    <ProjectReference Include=".*\\Test\\Stimuli\\TestApp\\Lib\\TestApp\.Lib\.csproj" \/>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="TestApp" Version="1.0.0" ExcludeAssets="All" />
+  </ItemGroup>
 </Project>

--- a/Test/Expected/DebugTestAppAssemblyRef/Ui/slnx.config
+++ b/Test/Expected/DebugTestAppAssemblyRef/Ui/slnx.config
@@ -2,5 +2,6 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Common" Version="6.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
+    <PackageReference Include="TestApp" Version="1.0.0" ExcludeAssets="All" />
   </ItemGroup>
 </Project>

--- a/Test/Expected/DebugTestAppNoRef/App/slnx.config
+++ b/Test/Expected/DebugTestAppNoRef/App/slnx.config
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="TestApp" Version="1.0.0" ExcludeAssets="All" />
+  </ItemGroup>
+</Project>

--- a/Test/Expected/DebugTestAppNugetRef/Ui/slnx.config
+++ b/Test/Expected/DebugTestAppNugetRef/Ui/slnx.config
@@ -2,5 +2,6 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Common" Version="6.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.0.0" />
+    <PackageReference Include="TestApp" Version="1.0.0" ExcludeAssets="All" />
   </ItemGroup>
 </Project>

--- a/Test/SlnLauncher.Test/DebugTestAppNoRefRefFileWriter.cs
+++ b/Test/SlnLauncher.Test/DebugTestAppNoRefRefFileWriter.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using Slnx.Interfaces;
+
+namespace SlnLauncher.Test
+{
+    internal class DebugTestAppNoRefFileWriter : AppBaseFileWriter
+    {
+        internal const string FolderName = "DebugTestAppNoRef";
+        internal string SlnxName = Path.Combine(FolderName, "DebugTestAppNoRef.slnx");
+
+        public DebugTestAppNoRefFileWriter() : base (FolderName)
+        {
+        }
+
+        protected override string GetPath(string path)
+        {
+            var filePartialPath = Path.Combine(_folderName, Path.GetFileName(Path.GetDirectoryName(path)), Path.GetFileName(path));
+            return TestHelper.GetResultPathFor(filePartialPath);
+        }
+    }
+}

--- a/Test/SlnLauncher.Test/Helper.cs
+++ b/Test/SlnLauncher.Test/Helper.cs
@@ -59,6 +59,15 @@ namespace SlnLauncher.Test
 
         private static bool Compare(string resultFile, string expectedFile, string skipUpTo, params string[] skip)
         {
+            if (!File.Exists(resultFile))
+            {
+                NUnit.Framework.TestContext.WriteLine($"Missing result file {resultFile}");
+            }
+            if (!File.Exists(expectedFile))
+            {
+                NUnit.Framework.TestContext.WriteLine($"Missing expected file {expectedFile}");
+            }
+
             var resultLines = File.ReadAllLines(resultFile);
             var expectedLines = File.ReadAllLines(GetExpectedPathFor(expectedFile));
             if (resultLines.Length == expectedLines.Length)
@@ -90,7 +99,7 @@ namespace SlnLauncher.Test
                         {
                             if (!skip.Any(x => resLine.Contains(x)))
                             {
-                                Console.WriteLine($"Error at line {i + 1} in {resultFile} vs {expectedFile}");
+                                NUnit.Framework.TestContext.WriteLine($"Error at line {i + 1} in {resultFile} vs {expectedFile}");
                                 break;
                             }
                         }
@@ -102,6 +111,16 @@ namespace SlnLauncher.Test
                 }
             }
             return false;
+        }
+
+        public static void AreFilesEqual(string resultFile, string expectedFile, params string[] skip)
+        {
+            var res = Compare(resultFile, expectedFile, skip);
+            if (!res)
+            {
+                NUnit.Framework.TestContext.WriteLine($"Expected file {expectedFile} does not match with {resultFile}");
+            }
+            NUnit.Framework.Assert.IsTrue(res);
         }
 
         internal static string GetStimulPathFor(string file)

--- a/Test/SlnLauncher.Test/SlnLauncherTests.cs
+++ b/Test/SlnLauncher.Test/SlnLauncherTests.cs
@@ -173,7 +173,7 @@ namespace SlnLauncher.Test
 
             SlnLauncher.Program.Main(TestHelper.GetArguments(new TestAppFileWriter().SlnxName, commandLineArg), new TestAppFileWriter());
 
-            Assert.IsTrue(TestHelper.Compare(resultFile, expectedFile));
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
         }
 
         [TestCase("TestApp.nuspec", "-ns", "pack")]
@@ -184,7 +184,7 @@ namespace SlnLauncher.Test
 
             SlnLauncher.Program.Main(TestHelper.GetArguments(new TestAppFileWriter().SlnxName, commandLineArg), new TestAppFileWriter());
 
-            Assert.IsTrue(TestHelper.Compare(resultFile, expectedFile));
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
         }
 
         [TestCase("TestApp.FailNoContent.slnx", typeof(Exception), "-ns", "pack")]
@@ -230,7 +230,7 @@ namespace SlnLauncher.Test
 
             SlnLauncher.Program.Main(TestHelper.GetArguments(new TestAppFileWriter().SlnxName), new TestAppFileWriter());
 
-            Assert.IsTrue(TestHelper.Compare(resultFile, expectedFile));
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
         }
 
         [Test]
@@ -256,7 +256,7 @@ namespace SlnLauncher.Test
 
             SlnLauncher.Program.Main(TestHelper.GetArguments(new TestAppFileWriter().SlnxName), new TestAppFileWriter());
 
-            Assert.IsTrue(TestHelper.Compare(resultFile, expectedFile));
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
         }
 
         [Test]
@@ -293,7 +293,7 @@ namespace SlnLauncher.Test
 
             var expectedFile = TestHelper.GetExpectedPathFor(Path.Combine(DebugTestAppAssemblyRefFileWriter.FolderName, subFolder, f));
             var resultFile = TestHelper.GetResultPathFor(Path.Combine(DebugTestAppAssemblyRefFileWriter.FolderName, subFolder, f));
-            Assert.IsTrue(TestHelper.Compare(resultFile, expectedFile));
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
         }
 
         [TestCase("DebugTestApp.ProjWithNugetRefToDebugPrj.csproj", "App")]
@@ -307,7 +307,7 @@ namespace SlnLauncher.Test
 
             var expectedFile = TestHelper.GetExpectedPathFor(Path.Combine(DebugTestAppNugetRefFileWriter.FolderName, subFolder, f));
             var resultFile = TestHelper.GetResultPathFor(Path.Combine(DebugTestAppNugetRefFileWriter.FolderName, subFolder, f));
-            Assert.IsTrue(TestHelper.Compare(resultFile, expectedFile));
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
         }
 
 
@@ -328,14 +328,15 @@ namespace SlnLauncher.Test
         ///
         /// Make sure that the debug information are properly propagated in the slnx.config
         /// </summary>
-        [TestCase("slnx.config", "Src")]
+        [TestCase(Slnx.CsProject.ImportSlnxConfigName, "Src")]
         public void DebugExtendedTestApp_CompareGeneratedFiles(string f, string subFolder)
         {
             SlnLauncher.Program.Main(TestHelper.GetArguments(new DebugExtendedTestAppNugetRefFileWriter().SlnxName), new DebugExtendedTestAppNugetRefFileWriter());
-            
+
             var expectedFile = TestHelper.GetExpectedPathFor(Path.Combine(DebugExtendedTestAppNugetRefFileWriter.FolderName, subFolder, f));
             var resultFile = TestHelper.GetResultPathFor(Path.Combine(DebugExtendedTestAppNugetRefFileWriter.FolderName, subFolder, f));
-            Assert.IsTrue(TestHelper.Compare(resultFile, expectedFile));
+
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
         }
     }
 }

--- a/Test/SlnLauncher.Test/SlnLauncherTests.cs
+++ b/Test/SlnLauncher.Test/SlnLauncherTests.cs
@@ -54,7 +54,7 @@ namespace SlnLauncher.Test
             {
                 if (!_originalVariables.ContainsKey(keys[i])) //Reset all new vars
                 {
-                    Console.WriteLine("Resetting: {0}", keys[i]);
+                    //Console.WriteLine("Resetting: {0}", keys[i]);
                     System.Environment.SetEnvironmentVariable(keys[i], null);
                 }
             }
@@ -194,10 +194,10 @@ namespace SlnLauncher.Test
         {
             var slnx = TestHelper.GetStimulPathFor(Path.Combine(TestAppFileWriter.FolderName, slnxName));
 
-            var errro = Assert.Throws(ex, () =>
+            var error = Assert.Throws(ex, () =>
                  SlnLauncher.Program.Main(TestHelper.GetArguments(slnx, commandLineArg), new TestAppFileWriter())
             );
-            Console.WriteLine(errro.Message);
+            //Console.WriteLine(error.Message);
         }
 
 
@@ -335,6 +335,17 @@ namespace SlnLauncher.Test
 
             var expectedFile = TestHelper.GetExpectedPathFor(Path.Combine(DebugExtendedTestAppNugetRefFileWriter.FolderName, subFolder, f));
             var resultFile = TestHelper.GetResultPathFor(Path.Combine(DebugExtendedTestAppNugetRefFileWriter.FolderName, subFolder, f));
+
+            TestHelper.AreFilesEqual(resultFile, expectedFile);
+        }
+
+        [TestCase(Slnx.CsProject.ImportSlnxConfigName, "App")]
+        public void DebugTestAppNoRe_CompareGeneratedFiles(string f, string subFolder)
+        {
+            SlnLauncher.Program.Main(TestHelper.GetArguments(new DebugTestAppNoRefFileWriter().SlnxName), new DebugTestAppNoRefFileWriter());
+
+            var expectedFile = TestHelper.GetExpectedPathFor(Path.Combine(DebugTestAppNoRefFileWriter.FolderName, subFolder, f));
+            var resultFile = TestHelper.GetResultPathFor(Path.Combine(DebugTestAppNoRefFileWriter.FolderName, subFolder, f));
 
             TestHelper.AreFilesEqual(resultFile, expectedFile);
         }

--- a/Test/Stimuli/DebugTestAppNoRef/App/Class1.cs
+++ b/Test/Stimuli/DebugTestAppNoRef/App/Class1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestApp.Lib
+{
+    internal class Class1
+    {
+    }
+}

--- a/Test/Stimuli/DebugTestAppNoRef/App/DebugTestApp.ProjWithNoRefs.csproj
+++ b/Test/Stimuli/DebugTestAppNoRef/App/DebugTestApp.ProjWithNoRefs.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+  </ItemGroup>
+</Project>

--- a/Test/Stimuli/DebugTestAppNoRef/DebugTestAppNoRef.slnx
+++ b/Test/Stimuli/DebugTestAppNoRef/DebugTestAppNoRef.slnx
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<SlnX searchPath="$(slnx)" packagesPath="C:\Nugetcache">
+    <env name="NUGET_ORG_URL">https://api.nuget.org/v3/index.json</env>
+    <env name="MY_VAR">%NUGET_ORG_URL%</env>
+    
+    <package id="TestApp" version="1.0.0" source="$(slnx)\..\Packages" />
+    
+    <!-- Projects -->
+    <project name="DebugTestApp.ProjWithNoRefs" />
+</SlnX>

--- a/Test/Stimuli/DebugTestAppNoRef/DebugTestAppNoRef.slnx.user
+++ b/Test/Stimuli/DebugTestAppNoRef/DebugTestAppNoRef.slnx.user
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<SlnX>
+    <debug>..\TestApp\TestApp.slnx</debug>
+</SlnX>

--- a/Test/Stimuli/DebugTestAppNoRef/Directory.Build.props
+++ b/Test/Stimuli/DebugTestAppNoRef/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+ <PropertyGroup>
+   <AssemblyVersion>1.0.0</AssemblyVersion>
+    <Version>$(AssemblyVersion)</Version> <!-- If repacked, it might be required to set this as the NuGet SDK. -->
+ </PropertyGroup>
+</Project>


### PR DESCRIPTION
Produce the debug information also for all debug packages not directly referenced by a particular C# Project
This instructs VS Studio not to take into account the debug package (via ExludeAssets = All) from a
dependency project which eventually (directly or indirectly) refers to such package.
